### PR TITLE
Fix SD card setup failure on ESP-IDF 4.2

### DIFF
--- a/src/services/sd_card.cpp
+++ b/src/services/sd_card.cpp
@@ -19,6 +19,8 @@ SDCard::setup()
   sdmmc_host_t        host        = SDSPI_HOST_DEFAULT();
   sdspi_slot_config_t slot_config = SDSPI_SLOT_CONFIG_DEFAULT();
 
+  host.flags = SDMMC_HOST_FLAG_SPI;
+
   slot_config.gpio_miso = PIN_NUM_MISO;
   slot_config.gpio_mosi = PIN_NUM_MOSI;
   slot_config.gpio_sck  = PIN_NUM_CLK;


### PR DESCRIPTION
This fixes #1

## Description

Overwrite `host_config->flags` set by `SDSPI_HOST_DEFAULT()` with `SDMMC_HOST_FLAG_SPI` same as ESP-IDF 4.1.


### ESP-IDF 4.1
`    .flags = SDMMC_HOST_FLAG_SPI, \`

https://github.com/espressif/esp-idf/blob/v4.1/components/driver/include/driver/sdspi_host.h#L36

### ESP-IDF 4.2
`    .flags = SDMMC_HOST_FLAG_SPI | SDMMC_HOST_FLAG_DEINIT_ARG, \`


https://github.com/espressif/esp-idf/blob/v4.2/components/driver/include/driver/sdspi_host.h#L39