### PR TITLE
Setup SDCard on 'sdCardInit' call

### DIFF
--- a/include/graphical/inkplate.hpp
+++ b/include/graphical/inkplate.hpp
@@ -21,6 +21,7 @@ Distributed as-is; no warranty is given.
 #include "graphics.hpp"
 #include "inkplate_platform.hpp"
 #include "network_client.hpp"
+#include "sd_card.hpp"
 
 class Inkplate : public Graphics
 {
@@ -45,7 +46,7 @@ class Inkplate : public Graphics
     inline void         disconnect() { network_client.disconnect();              }
     inline bool        isConnected() { return network_client.isConnected();      }
     inline int        _getRotation() { return Graphics::getRotation();           }
-    inline bool         sdCardInit() { return true;                              }
+    inline bool         sdCardInit() { return SDCard::setup();                   }
     inline uint16_t      einkWidth() { return e_ink.get_width();                 }
     inline uint16_t     einkHeight() { return e_ink.get_height();                }
 

--- a/include/services/sd_card.hpp
+++ b/include/services/sd_card.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cinttypes>
+
 class SDCard
 {
   public:
@@ -16,4 +18,6 @@ class SDCard
 
   private:
     static constexpr char const * TAG = "SDCard";
+    enum class SDCardState : uint8_t { UNINITIALIZED, INITIALIZED, FAILED };
+    static SDCardState state;
 };


### PR DESCRIPTION
An example of Peripheral Mode doesn't work well when [`#H` command](https://github.com/turgu1/ESP-IDF-InkPlate/blob/v0.9.5/examples/Others/Inkplate_Peripheral_Mode/src/main.cpp#L235-L260) was sent.
I found why, because 
1. [`display.setup()`](https://github.com/turgu1/ESP-IDF-InkPlate/blob/v0.9.5/examples/Others/Inkplate_Peripheral_Mode/src/main.cpp#L59) does not have an optional argument `sd_card_init`
2. and [`display.sdCardInit()`](https://github.com/turgu1/ESP-IDF-InkPlate/blob/3340afab9e2323fef2c0e9516a12bb1a433f8121/include/graphical/inkplate.hpp#L48) does nothing.

I get `display.sdCardInit()` working.