### PR TITLE
Fix color palette bit shift bug

### DIFF
--- a/src/graphical/image_bmp.cpp
+++ b/src/graphical/image_bmp.cpp
@@ -182,7 +182,7 @@ void Image::displayBmpLine(int16_t x, int16_t y, bitmapHeader *bmpHeader, bool d
             if (dither)
                 val = ditherGetPixelBmp(px, j, w, 1);
             else
-                val = palette[px >> 1] & (px & 1 ? 0x0F : 0xF0) >> (px & 1 ? 0 : 4);
+                val = (palette[px >> 1] & (px & 1 ? 0x0F : 0xF0)) >> (px & 1 ? 0 : 4);
             if (invert)
                 val = 7 - val;
             if (getDisplayMode() == DisplayMode::INKPLATE_1BIT)
@@ -198,7 +198,7 @@ void Image::displayBmpLine(int16_t x, int16_t y, bitmapHeader *bmpHeader, bool d
             if (dither)
                 val = ditherGetPixelBmp(px, j, w, 1);
             else
-                val = palette[px >> 1] & (px & 1 ? 0x0F : 0xF0) >> (px & 1 ? 0 : 4);
+                val = (palette[px >> 1] & (px & 1 ? 0x0F : 0xF0)) >> (px & 1 ? 0 : 4);
             if (invert)
                 val = 7 - val;
             if (getDisplayMode() == DisplayMode::INKPLATE_1BIT)


### PR DESCRIPTION
When displaying a 4-bit or 8-bit bmp image without dithering, the colors are retrieved incorrectly from the color palette.

```cpp
  display.drawImage("/sdcard/grad.bmp", 0, 0, false, false);
```

[Original image](https://gist.githubusercontent.com/mzyy94/63115e9d0b3f0e0a4803713d8d7ac6e2/raw/29bd1bce9a8f3f03fcf82fa86c18cc713f325e30/grad.bmp) | [master](https://github.com/turgu1/ESP-IDF-InkPlate/commit/9365c7f50a238ed2eef4d6c9551132e87f19343f) | This patch
---|---|---
![grad](https://gist.githubusercontent.com/mzyy94/63115e9d0b3f0e0a4803713d8d7ac6e2/raw/29bd1bce9a8f3f03fcf82fa86c18cc713f325e30/grad.bmp) | ![IMG_4167](https://user-images.githubusercontent.com/2971112/149543106-201b4ed9-37db-4b9d-8300-d3dcf7756e02.jpg) | ![IMG_4166](https://user-images.githubusercontent.com/2971112/149543145-e0c19a6e-f83b-4d57-9737-32d9d71db8f9.jpg)

