### PR TITLE
Added support for Inkplates that are missing second MCP

### DIFF
--- a/examples/Basic_Inkplate_Functionality/Inkplate-basic_custom_font/src/main.cpp
+++ b/examples/Basic_Inkplate_Functionality/Inkplate-basic_custom_font/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-   Basic_custom_font example for e-radionica.com Inkplate 6
+   Basic_custom_font example for Soldered Inkplate 6
    For this example you will need only USB cable and Inkplate 6
    Select "Inkplate 6(ESP32)" from Tools -> Board menu.
    Don't have "Inkplate 6(ESP32)" option? Follow our tutorial and add it:
@@ -16,8 +16,15 @@
 
    Want to learn more about Inkplate? Visit www.inkplate.io
    Looking to get support? Write on our forums: http://forum.e-radionica.com/en/
-   15 July 2020 by e-radionica.com
+   15 July 2020 by Soldered
 */
+
+// If your Inkplate doesn't have external (or second) MCP I/O expander, you should uncomment next line,
+// otherwise your code could hang out when you send code to your Inkplate.
+// You can easily check if your Inkplate has second MCP by turning it over and 
+// if there is missing chip near place where "MCP23017-2" is written, but if there is
+// chip soldered, you don't have to uncomment line and use external MCP I/O expander
+//#define ONE_MCP_MODE
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/examples/Basic_Inkplate_Functionality/Inkplate-basic_partial_update/src/main.cpp
+++ b/examples/Basic_Inkplate_Functionality/Inkplate-basic_partial_update/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-   Basic_partial_update example for e-radionica Inkplate 6
+   Basic_partial_update example for Soldered Inkplate 6
    For this example you will need only USB cable and Inkplate 6
    Select "Inkplate 6(ESP32)" from Tools -> Board menu.
    Don't have "Inkplate 6(ESP32)" option? Follow our tutorial and add it:
@@ -12,8 +12,15 @@
 
    Want to learn more about Inkplate? Visit www.inkplate.io
    Looking to get support? Write on our forums: http://forum.e-radionica.com/en/
-   15 July 2020 by e-radionica.com
+   15 July 2020 by Soldered
 */
+
+// If your Inkplate doesn't have external (or second) MCP I/O expander, you should uncomment next line,
+// otherwise your code could hang out when you send code to your Inkplate.
+// You can easily check if your Inkplate has second MCP by turning it over and 
+// if there is missing chip near place where "MCP23017-2" is written, but if there is
+// chip soldered, you don't have to uncomment line and use external MCP I/O expander
+//#define ONE_MCP_MODE
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/examples/Basic_Inkplate_Functionality/Inkplate_basic_BW/src/main.cpp
+++ b/examples/Basic_Inkplate_Functionality/Inkplate_basic_BW/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-   Basic_monochorme example for e-radionica.com Inkplate devices
+   Basic_monochorme example for Soldered Inkplate devices
    For this example you will need only USB cable and Inkplate.
    Select "Inkplate 6(ESP32)" from Tools -> Board menu.
    Don't have "Inkplate 6(ESP32)" option? Follow our tutorial and add it:
@@ -11,8 +11,15 @@
 
    Want to learn more about Inkplate? Visit www.inkplate.io
    Looking to get support? Write on our forums: http://forum.e-radionica.com/en/
-   15 July 2020 by e-radionica.com
+   15 July 2020 by Soldered.com
 */
+
+// If your Inkplate doesn't have external (or second) MCP I/O expander, you should uncomment next line,
+// otherwise your code could hang out when you send code to your Inkplate.
+// You can easily check if your Inkplate has second MCP by turning it over and 
+// if there is missing chip near place where "MCP23017-2" is written, but if there is
+// chip soldered, you don't have to uncomment line and use external MCP I/O expander
+//#define ONE_MCP_MODE
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/examples/Basic_Inkplate_Functionality/Inkplate_basic_gray/src/main.cpp
+++ b/examples/Basic_Inkplate_Functionality/Inkplate_basic_gray/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-   Basic_gray example for e-radionica.com Inkplate 6
+   Basic_gray example for Soldered Inkplate 6
    For this example you will need only USB cable and Inkplate 6
    Select "Inkplate 6(ESP32)" from Tools -> Board menu.
    Don't have "Inkplate 6(ESP32)" option? Follow our tutorial and add it:
@@ -14,8 +14,15 @@
 
    Want to learn more about Inkplate? Visit www.inkplate.io
    Looking to get support? Write on our forums: http://forum.e-radionica.com/en/
-   15 July 2020 by e-radionica.com
+   15 July 2020 by Soldered
 */
+
+// If your Inkplate doesn't have external (or second) MCP I/O expander, you should uncomment next line,
+// otherwise your code could hang out when you send code to your Inkplate.
+// You can easily check if your Inkplate has second MCP by turning it over and 
+// if there is missing chip near place where "MCP23017-2" is written, but if there is
+// chip soldered, you don't have to uncomment line and use external MCP I/O expander
+//#define ONE_MCP_MODE
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/examples/Others/Inkplate_Mandelbrot_set/src/main.cpp
+++ b/examples/Others/Inkplate_Mandelbrot_set/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-   Inkplate_Mandelbrot_set sketch for e-radionica.com Inkplate devices
+   Inkplate_Mandelbrot_set sketch for Soldered Inkplate devices
    Select "Inkplate 6(ESP32)" from Tools -> Board menu.
    Don't have "Inkplate 6(ESP32)" option? Follow our tutorial and add it:
    https://e-radionica.com/en/blog/add-inkplate-6-to-arduino-ide/
@@ -9,8 +9,15 @@
 
    Want to learn more about Inkplate? Visit www.inkplate.io
    Looking to get support? Write on our forums: http://forum.e-radionica.com/en/
-   15 July 2020 by e-radionica.com
+   15 July 2020 by Soldered
 */
+
+// If your Inkplate doesn't have external (or second) MCP I/O expander, you should uncomment next line,
+// otherwise your code could hang out when you send code to your Inkplate.
+// You can easily check if your Inkplate has second MCP by turning it over and 
+// if there is missing chip near place where "MCP23017-2" is written, but if there is
+// chip soldered, you don't have to uncomment line and use external MCP I/O expander
+//#define ONE_MCP_MODE
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/examples/Others/Inkplate_Maze_Generator/src/main.cpp
+++ b/examples/Others/Inkplate_Maze_Generator/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-   Inkplate_Maze_Generator sketch for e-radionica.com Inkplate 6
+   Inkplate_Maze_Generator sketch for Soldered Inkplate 6
    Select "Inkplate 6(ESP32)" from Tools -> Board menu.
    Don't have "Inkplate 6(ESP32)" option? Follow our tutorial and add it:
    https://e-radionica.com/en/blog/add-inkplate-6-to-arduino-ide/
@@ -10,8 +10,15 @@
 
    Want to learn more about Inkplate? Visit www.inkplate.io
    Looking to get support? Write on our forums: http://forum.e-radionica.com/en/
-   15 July 2020 by e-radionica.com
+   15 July 2020 by Soldered
 */
+
+// If your Inkplate doesn't have external (or second) MCP I/O expander, you should uncomment next line,
+// otherwise your code could hang out when you send code to your Inkplate.
+// You can easily check if your Inkplate has second MCP by turning it over and 
+// if there is missing chip near place where "MCP23017-2" is written, but if there is
+// chip soldered, you don't have to uncomment line and use external MCP I/O expander
+//#define ONE_MCP_MODE
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/examples/Others/Inkplate_Peripheral_Mode/src/main.cpp
+++ b/examples/Others/Inkplate_Peripheral_Mode/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-   Inkplate_Peripheral_Mode sketch for e-radionica.com Inkplate 6
+   Inkplate_Peripheral_Mode sketch for Soldered Inkplate 6
    Select "Inkplate 6(ESP32)" from Tools -> Board menu.
    Don't have "Inkplate 6(ESP32)" option? Follow our tutorial and add it:
    https://e-radionica.com/en/blog/add-inkplate-6-to-arduino-ide/
@@ -23,8 +23,15 @@
 
    Want to learn more about Inkplate? Visit www.inkplate.io
    Looking to get support? Write on our forums: http://forum.e-radionica.com/en/
-   15 July 2020 by e-radionica.com
+   15 July 2020 by Soldered
 */
+
+// If your Inkplate doesn't have external (or second) MCP I/O expander, you should uncomment next line,
+// otherwise your code could hang out when you send code to your Inkplate.
+// You can easily check if your Inkplate has second MCP by turning it over and 
+// if there is missing chip near place where "MCP23017-2" is written, but if there is
+// chip soldered, you don't have to uncomment line and use external MCP I/O expander
+//#define ONE_MCP_MODE
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/examples/Others/Inkplate_VariPass_Graphs/src/main.cpp
+++ b/examples/Others/Inkplate_VariPass_Graphs/src/main.cpp
@@ -21,8 +21,15 @@
 
    Want to learn more about Inkplate? Visit www.inkplate.io
    Looking to get support? Write on our forums: http://forum.e-radionica.com/en/
-   23 July 2020 by e-radionica.com
+   23 July 2020 by Soldered
 */
+
+// If your Inkplate doesn't have external (or second) MCP I/O expander, you should uncomment next line,
+// otherwise your code could hang out when you send code to your Inkplate.
+// You can easily check if your Inkplate has second MCP by turning it over and 
+// if there is missing chip near place where "MCP23017-2" is written, but if there is
+// chip soldered, you don't have to uncomment line and use external MCP I/O expander
+//#define ONE_MCP_MODE
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/src/drivers/eink_10.cpp
+++ b/src/drivers/eink_10.cpp
@@ -93,12 +93,14 @@ EInk10::setup()
 
   wakeup_clear();
 
+#ifndef ONE_MCP_MODE
   // Set all pins of seconds I/O expander to outputs, low.
   // For some reason, it draw more current in deep sleep when pins are set as inputs...
   for (int i = 0; i < 15; i++) {
     mcp_ext.set_direction((MCP23017::Pin) i, MCP23017::PinMode::OUTPUT);
     mcp_ext.digital_write((MCP23017::Pin) i, MCP23017::SignalLevel::LOW);
   }
+#endif
 
   // For same reason, unused pins of first I/O expander have to be also set as outputs, low.
   mcp_int.set_direction(MCP23017::Pin::IOPIN_13, MCP23017::PinMode::OUTPUT);

--- a/src/drivers/eink_6plus.cpp
+++ b/src/drivers/eink_6plus.cpp
@@ -89,12 +89,14 @@ EInk6PLUS::setup()
 
   wakeup_clear();
 
+#ifndef ONE_MCP_MODE
   // Set all pins of seconds I/O expander to outputs, low.
   // For some reason, it draw more current in deep sleep when pins are set as inputs...
   for (int i = 0; i < 15; i++) {
     mcp_ext.set_direction((MCP23017::Pin) i, MCP23017::PinMode::OUTPUT);
     mcp_ext.digital_write((MCP23017::Pin) i, MCP23017::SignalLevel::LOW);
   }
+#endif
 
   // For same reason, unused pins of first I/O expander have to be also set as outputs, low.
   mcp_int.set_direction(MCP23017::Pin::IOPIN_13, MCP23017::PinMode::OUTPUT);


### PR DESCRIPTION
New Inkplates are shipped without second MCP I/O expander because of chip shortage. If Inkplate without second MCP I/O expander is programmed using this library, it will hang out on function that is setting it's pins to LOW state, so in this commit is added part of code which stops it.