### PR TITLE
Menuconfig variant selection + Certificate bundling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,18 @@ FILE(GLOB_RECURSE inkplate_srcs src/**/*.cpp)
 FILE(GLOB inkplate_include_dirs include/*)
 LIST(FILTER inkplate_include_dirs EXCLUDE REGEX ".*/README$")
 
+if(CONFIG_INKPLATE_VARIANT_10)
+    set(INKPLATE_VARIANT "INKPLATE_10")
+elseif(CONFIG_INKPLATE_VARIANT_6PLUS)
+    set(INKPLATE_VARIANT "INKPLATE_6PLUS")
+elseif(CONFIG_INKPLATE_VARIANT_6)
+    set(INKPLATE_VARIANT "INKPLATE_6")
+endif()
+
 idf_component_register(
     SRCS ${inkplate_srcs}
     INCLUDE_DIRS ${inkplate_include_dirs}
     REQUIRES fatfs nvs_flash esp_http_client
 )
+
+target_compile_definitions(${COMPONENT_LIB} PUBLIC ${INKPLATE_VARIANT})

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,12 @@
+menu "Inkplate"
+    choice INKPLATE_VARIANT_CHOOSE
+        prompt "Choose your Inkplate variant"
+        default INKPLATE_VARIANT_10
+        config INKPLATE_VARIANT_10
+            bool "Inkplate 10"
+        config INKPLATE_VARIANT_6
+            bool "Inkplate 6"
+        config INKPLATE_VARIANT_6PLUS
+            bool "Inkplate 6Plus"
+    endchoice
+endmenu

--- a/examples/Native_IDF/Hello_World/CMakeLists.txt
+++ b/examples/Native_IDF/Hello_World/CMakeLists.txt
@@ -1,8 +1,4 @@
 cmake_minimum_required(VERSION 3.5)
 
-# change based on your device
-# possible values: INKPLATE_6, INKPLATE_6PLUS, INKPLATE_10
-add_compile_definitions(INKPLATE_10)
-
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(Hello_World)

--- a/examples/Native_IDF/Hello_World/README.md
+++ b/examples/Native_IDF/Hello_World/README.md
@@ -4,7 +4,7 @@ The purpose of this example is to show how to use the ESP-IDF-InkPlate library w
 
 The program will only display a message "Hello World" in the center of the screen and then exit the program. It includes freertos, idf and inkplate headers and can stand as a simple test whether your esp-idf installation is working correctly.
 
-**The example was tested only with ESP-IDF version 4.4.1.** However, as the library and example itself are made as universal as they could, past and future versions should work as well. If not, please open a new [issue](https://github.com/turgu1/ESP-IDF-InkPlate/issues) and let us know.
+**The example was tested only with ESP-IDF version 4.4.1.** However, as the library and example itself were made as universal as they could, past and future versions should work as well. If not, please open a new [issue](https://github.com/turgu1/ESP-IDF-InkPlate/issues) and let us know.
 
 ## Configuration
 
@@ -12,7 +12,7 @@ The program will only display a message "Hello World" in the center of the scree
 
 ## Installation
 
-Either download the inkplate library or link it as a git submodule and place it in the components/ folder.
+Either download the Inkplate library or link it as a git submodule and place it in the components/ folder.
 
 ```sh
 # to make it a submodule of your repository

--- a/examples/Native_IDF/Hello_World/README.md
+++ b/examples/Native_IDF/Hello_World/README.md
@@ -16,12 +16,12 @@ Either download the Inkplate library or link it as a git submodule and place it 
 
 ```sh
 # to make it a submodule of your repository
-git submodule add -b v0.9.6 https://github.com/turgu1/ESP-IDF-InkPlate.git components/inkplate
+git submodule add -b master https://github.com/turgu1/ESP-IDF-InkPlate.git components/inkplate
 
 # or
 
-# to use a different version of the library, modify the submodule's branch accordingly
-git submodule add -b master https://github.com/turgu1/ESP-IDF-InkPlate.git components/inkplate
+# to use a specific version of the library, modify the submodule's branch accordingly
+git submodule add -b v0.9.6 https://github.com/turgu1/ESP-IDF-InkPlate.git components/inkplate
 ```
 
 ## Compile and run

--- a/examples/Native_IDF/Hello_World/README.md
+++ b/examples/Native_IDF/Hello_World/README.md
@@ -8,7 +8,7 @@ The program will only display a message "Hello World" in the center of the scree
 
 ## Configuration
 
-`sdkconfig` should be already preconfigured for the InkPlate ESP32 board. What requires your attention is the variant of your InkPlate device. This example targets InkPlate 10. If you are using a different InkPlate variant, modify the project compile definitions in [CMakeLists.txt](./CMakeLists.txt) according to your device.
+`sdkconfig` should be already preconfigured for the Inkplate 10 device. To change your Inkplate variant, go to `Component config --> Inkplate --> Choose your Inkplate variant` and change it accordingly.
 
 ## Installation
 

--- a/examples/Native_IDF/Hello_World/sdkconfig
+++ b/examples/Native_IDF/Hello_World/sdkconfig
@@ -1297,6 +1297,14 @@ CONFIG_WPA_MBEDTLS_CRYPTO=y
 # CONFIG_WPA_WPS_STRICT is not set
 # CONFIG_WPA_11KV_SUPPORT is not set
 # end of Supplicant
+
+#
+# Inkplate
+#
+CONFIG_INKPLATE_VARIANT_10=y
+# CONFIG_INKPLATE_VARIANT_6 is not set
+# CONFIG_INKPLATE_VARIANT_6PLUS is
+# end of Inkplate
 # end of Component config
 
 #

--- a/src/services/network_client.cpp
+++ b/src/services/network_client.cpp
@@ -32,6 +32,10 @@ Distributed as-is; no warranty is given.
 
 #include "esp_http_client.h"
 
+#if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+#include "esp_crt_bundle.h"
+#endif
+
 static constexpr char const * TAG = "NetworkClient";
 
 static const uint8_t ESP_MAXIMUM_RETRY = 6;
@@ -260,6 +264,10 @@ NetworkClient::downloadFile(const char * url, int32_t * defaultLen)
   
   config.url = url;
   config.event_handler = http_event_handler;
+
+  #if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+  config.crt_bundle_attach = esp_crt_bundle_attach;
+  #endif
   
   esp_http_client_handle_t client = esp_http_client_init(&config);
   esp_err_t err = esp_http_client_perform(client);


### PR DESCRIPTION
* added Kconfig to the root of the repository for our own menuconfig screen
* updated Native-IDF example to use variables from menuconfig instead of manual editing of CMakeLists
* updated Native-DF README to suggest the master branch as the first option

**to potentially be separated into its own PR**
* bundle common TLS certificates in network_client if the user has `MBEDTLS_CERTIFICATE_BUNDLE` enabled in sdkconfig