### PR TITLE
A fix for a new regression in stable v5.0

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,5 @@
+version: "idf-v5.0-support"
+description: "A porting effort to the ESP-IDF framework for the e-Radionica InkPlate software."
+dependencies:
+  idf:
+    version: ">=5.0"

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "idf-v5.0-support"
+version: "0.9.8"
 description: "A porting effort to the ESP-IDF framework for the e-Radionica InkPlate software."
 dependencies:
   idf:

--- a/include/services/esp.hpp
+++ b/include/services/esp.hpp
@@ -64,7 +64,7 @@ class ESP
         mem = heap_caps_malloc(size, MALLOC_CAP_SPIRAM); 
       }
       if (mem == nullptr) {
-        ESP_LOGE(TAG, "Not enough memory on PSRAM!!! (Asking %u bytes)", size);
+        ESP_LOGE(TAG, "Not enough memory on PSRAM!!! (Asking %lu bytes)", size);
       }
       return mem;
     }

--- a/src/drivers/mcp23017.cpp
+++ b/src/drivers/mcp23017.cpp
@@ -21,6 +21,9 @@ Distributed as-is; no warranty is given.
 */
 
 #define __MCP__ 1
+
+#include <cinttypes>
+
 #include "mcp23017.hpp"
 #include "esp_log.h"
 
@@ -32,7 +35,7 @@ Distributed as-is; no warranty is given.
 bool
 MCP23017::check_presence()
 {
-  if (!present) ESP_LOGE(TAG, "The MCP at address 0x%X has not been detected.", mcp_address);
+  if (!present) ESP_LOGE(TAG, "The MCP at address 0x%" PRIX8 " has not been detected.", mcp_address);
   return present;
 }
 
@@ -69,7 +72,7 @@ MCP23017::setup()
   wire.begin_transmission(mcp_address);
   present = wire.end_transmission() == ESP_OK;
   
-  ESP_LOGI(TAG, "MCP at address 0x%X has%s been detected", mcp_address, present ? "" : " NOT");
+  ESP_LOGI(TAG, "MCP at address 0x%" PRIX8 " has%s been detected", mcp_address, present ? "" : " NOT");
 
   read_all_registers();
   registers[Reg::IODIRA] = 0xff;

--- a/src/services/network_client.cpp
+++ b/src/services/network_client.cpp
@@ -19,6 +19,7 @@ Distributed as-is; no warranty is given.
 #include "esp_log.h"
 
 #include <string.h>
+#include <cinttypes>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/event_groups.h"
@@ -60,7 +61,7 @@ static void sta_event_handler(void            * arg,
                               int32_t           event_id, 
                               void            * event_data)
 {
-  ESP_LOGI(TAG, "STA Event, Base: %08x, Event: %ld.", (unsigned int) event_base, event_id);
+  ESP_LOGI(TAG, "STA Event, Base: %08x, Event: %" PRIu32 ".", (unsigned int) event_base, event_id);
 
   if (event_base == WIFI_EVENT) {
     if (event_id == WIFI_EVENT_STA_START) {
@@ -212,7 +213,7 @@ static esp_err_t http_event_handler(esp_http_client_event_t * evt)
       //ESP_LOGI(TAG, "key = %s, value = %s", evt->header_key, evt->header_value);
       if (strcmp("Content-Length", evt->header_key) == 0) {
         buffer_size = atoi(evt->header_value);
-        ESP_LOGI(TAG, "Donwload file size: %ld", buffer_size);
+        ESP_LOGI(TAG, "Donwload file size: %" PRIi32, buffer_size);
       }
       break;
     case HTTP_EVENT_ON_DATA:
@@ -276,7 +277,7 @@ NetworkClient::downloadFile(const char * url, int32_t * defaultLen)
   esp_err_t err = esp_http_client_perform(client);
 
   if (err == ESP_OK) {
-    ESP_LOGI(TAG, "Status = %d, content_length = %lld",
+    ESP_LOGI(TAG, "Status = %d, content_length = %" PRIi64,
             esp_http_client_get_status_code(client),
             esp_http_client_get_content_length(client));
   }

--- a/src/services/network_client.cpp
+++ b/src/services/network_client.cpp
@@ -60,7 +60,7 @@ static void sta_event_handler(void            * arg,
                               int32_t           event_id, 
                               void            * event_data)
 {
-  ESP_LOGI(TAG, "STA Event, Base: %08x, Event: %d.", (unsigned int) event_base, event_id);
+  ESP_LOGI(TAG, "STA Event, Base: %08x, Event: %ld.", (unsigned int) event_base, event_id);
 
   if (event_base == WIFI_EVENT) {
     if (event_id == WIFI_EVENT_STA_START) {
@@ -212,7 +212,7 @@ static esp_err_t http_event_handler(esp_http_client_event_t * evt)
       //ESP_LOGI(TAG, "key = %s, value = %s", evt->header_key, evt->header_value);
       if (strcmp("Content-Length", evt->header_key) == 0) {
         buffer_size = atoi(evt->header_value);
-        ESP_LOGI(TAG, "Donwload file size: %d", buffer_size);
+        ESP_LOGI(TAG, "Donwload file size: %ld", buffer_size);
       }
       break;
     case HTTP_EVENT_ON_DATA:
@@ -276,7 +276,7 @@ NetworkClient::downloadFile(const char * url, int32_t * defaultLen)
   esp_err_t err = esp_http_client_perform(client);
 
   if (err == ESP_OK) {
-    ESP_LOGI(TAG, "Status = %d, content_length = %d",
+    ESP_LOGI(TAG, "Status = %d, content_length = %lld",
             esp_http_client_get_status_code(client),
             esp_http_client_get_content_length(client));
   }

--- a/src/services/wire.cpp
+++ b/src/services/wire.cpp
@@ -47,7 +47,7 @@ Wire::begin_transmission(uint8_t addr)
 {
   if (!initialized) setup();
 
-  ESP_LOGD(TAG, "Begin Transmission to address %x", addr);
+  ESP_LOGD(TAG, "Begin Transmission to address %" PRIx8, addr);
 
   if (initialized) {
     address = addr;


### PR DESCRIPTION
Related issue: https://github.com/espressif/esp-idf/issues/10379

I just changed `%d` to `%ld` and the compiler seems to be happy now.

EDIT: I've also changed components version number in `idf_component.yml` back to `0.9.8` because idf component manager complained about the version not being semantic.