### PR TITLE
Log configured device in native example

### DIFF
--- a/examples/Native_IDF/Hello_World/main/main.cpp
+++ b/examples/Native_IDF/Hello_World/main/main.cpp
@@ -23,7 +23,7 @@ static const char * TAG = "Main";
 
 void mainTask(void * param)
 {
-  ESP_LOGI(TAG, "Main task has started");
+  ESP_LOGI(TAG, "Main task has started, configured as %s", INKPLATE_VARIANT);
 
   display.begin();                    // Init Inkplate library (you should call this function ONLY ONCE)
   display.clearDisplay();             // Clear frame buffer of display

--- a/include/graphical/inkplate.hpp
+++ b/include/graphical/inkplate.hpp
@@ -23,6 +23,16 @@ Distributed as-is; no warranty is given.
 #include "network_client.hpp"
 #include "sd_card.hpp"
 
+#if defined(INKPLATE_10)
+  #define INKPLATE_VARIANT "INKPLATE_10"
+#elif defined(INKPLATE_6PLUS)
+    #define INKPLATE_VARIANT "INKPLATE_6PLUS"
+#elif defined(INKPLATE_6)
+    #define INKPLATE_VARIANT "INKPLATE_6"
+#else
+    #define INKPLATE_VARIANT "UNDEFINED"
+#endif
+
 class Inkplate : public Graphics
 {
   public:


### PR DESCRIPTION
I personally tripped over this in [#18](https://github.com/turgu1/ESP-IDF-InkPlate/issues/18). The documentation exists to avoid getting this wrong, but I think it'd be nice to have some kind of output at runtime.

This logs the configuration, so the message looks something like:
```
I (1538) Main: Main task has started, configured as INKPLATE_6PLUS
```

I'm _terrible_ at C++, so very open to there being a better way to do this.