### PR TITLE
Native IDF: Compensate for rendered text dimensions

### DIFF
--- a/examples/Native_IDF/Hello_World/main/main.cpp
+++ b/examples/Native_IDF/Hello_World/main/main.cpp
@@ -32,11 +32,23 @@ void mainTask(void * param)
   display.setTextSize(4);             // Set text to be 4 times bigger than classic 5x7 px text
 
   // Prepare message text and position
-  char message[] = "Hello World";
-  int w = display.width();
-  int h = display.height();
-  int cursor_x = (w / 2) - (strlen(message) / 2);
-  int cursor_y = h / 2;
+  const char message[] = "Hello World";
+
+  // Initializing these is effectively meaningless in this context
+  int16_t current_x = 0;
+  int16_t current_y = 0;
+  uint16_t message_width = 0;
+  uint16_t message_height = 0;
+  
+  // Not used but necessary to invoke getTextBounds
+  int16_t boundary_x = 0;
+  int16_t boundary_y = 0;
+
+  // Determine the dimensions of the text given our display configuration 
+  display.getTextBounds(message, current_x, current_y, &boundary_x, &boundary_y, &message_width, &message_height);
+
+  int cursor_x = (display.width() / 2) - (message_width / 2);
+  int cursor_y = (display.height() / 2) - (message_height / 2);
 
   ESP_LOGI(TAG, "Display size: width: %d, height: %d", w, h);
 


### PR DESCRIPTION
The documentation indicates this program is intended to center the text "Hello World". Noticing the off-center text, I was worried I had messed up some other configuration somewhere. The legacy implementation determined the offset by the number of characters in the string, but to center the text the offset should consider the rendered size of the characters.

Acknowledging this is supposed to be a simple example, I'm open to this change complicating it undesirably.

### Before
![before](https://user-images.githubusercontent.com/3683198/217657499-ce58654f-cb2e-4b80-bced-a12c24b5b5f7.jpeg)

### After
![after](https://user-images.githubusercontent.com/3683198/217657505-fcdc1025-fb0f-4a8c-9a90-46f58b889f4a.jpeg)

